### PR TITLE
Add a readonly mode to payload index

### DIFF
--- a/lib/segment/src/index/struct_payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index.rs
@@ -11,7 +11,9 @@ use rocksdb::DB;
 use schemars::_serde_json::Value;
 
 use crate::common::arc_atomic_ref_cell_iterator::ArcAtomicRefCellIterator;
-use crate::common::rocksdb_wrapper::open_db_with_existing_cf;
+use crate::common::rocksdb_wrapper::{
+    open_db_read_only_with_existing_cf, open_db_with_existing_cf,
+};
 use crate::common::utils::{IndexesMap, JsonPathPayload, MultiValue};
 use crate::common::Flusher;
 use crate::entry::entry_point::{OperationError, OperationResult};
@@ -51,6 +53,12 @@ pub struct StructPayloadIndex {
     /// Used to select unique point ids
     visited_pool: VisitedPool,
     db: Arc<RwLock<DB>>,
+}
+
+enum OpenType {
+    ReadWrite,
+    Appendable,
+    ReadOnly,
 }
 
 impl StructPayloadIndex {
@@ -143,6 +151,32 @@ impl StructPayloadIndex {
         path: &Path,
         is_appendable: bool,
     ) -> OperationResult<Self> {
+        Self::_open(
+            payload,
+            id_tracker,
+            path,
+            if is_appendable {
+                OpenType::Appendable
+            } else {
+                OpenType::ReadWrite
+            },
+        )
+    }
+
+    pub fn open_read_only(
+        payload: Arc<AtomicRefCell<PayloadStorageEnum>>,
+        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+        path: &Path,
+    ) -> OperationResult<Self> {
+        Self::_open(payload, id_tracker, path, OpenType::ReadOnly)
+    }
+
+    fn _open(
+        payload: Arc<AtomicRefCell<PayloadStorageEnum>>,
+        id_tracker: Arc<AtomicRefCell<IdTrackerSS>>,
+        path: &Path,
+        open_type: OpenType,
+    ) -> OperationResult<Self> {
         create_dir_all(path)?;
         let config_path = PayloadConfig::get_config_path(path);
         let config = if config_path.exists() {
@@ -151,8 +185,13 @@ impl StructPayloadIndex {
             PayloadConfig::default()
         };
 
-        let db = open_db_with_existing_cf(path)
-            .map_err(|err| OperationError::service_error(format!("RocksDB open error: {err}")))?;
+        let is_read_only = matches!(open_type, OpenType::ReadOnly);
+        let db = if is_read_only {
+            open_db_read_only_with_existing_cf(path)
+        } else {
+            open_db_with_existing_cf(path)
+        }
+        .map_err(|err| OperationError::service_error(format!("RocksDB open error: {err}")))?;
 
         let mut index = StructPayloadIndex {
             payload,
@@ -164,12 +203,12 @@ impl StructPayloadIndex {
             db,
         };
 
-        if !index.config_path().exists() {
+        if !is_read_only && !index.config_path().exists() {
             // Save default config
             index.save_config()?;
         }
 
-        index.load_all_fields(is_appendable)?;
+        index.load_all_fields(matches!(open_type, OpenType::Appendable))?;
 
         Ok(index)
     }


### PR DESCRIPTION
I had to change the clap version to be compatible with requirements in Convex. I also needed to add a specific revision to quantization to avoid a compilation error where cargo seemed to not find the library. 

Otherwise this is a pretty small (and hopefully maintainable!) change to qdrant that allows us to open payload storage's rocks db instance in readonly mode. We could already do so via public APIs for segments, but not for payloads. 

An even smaller change would be to just make some more of the struct's fields public and copy/paste a bit more in our code to open the rocks db instance directly. 