### PR TITLE
Set the portable flag for RocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,17 +682,16 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "cexpr",
  "clang-sys",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
- "prettyplease 0.2.4",
  "proc-macro2",
  "quote",
  "regex",
@@ -2526,9 +2525,8 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+version = "0.16.0+8.10.0"
+source = "git+https://github.com/sujayakar/rust-rocksdb?rev=8651632f2d0b86a56cbad4fa4adaa4bf1ca96e2c#8651632f2d0b86a56cbad4fa4adaa4bf1ca96e2c"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3206,12 +3204,6 @@ dependencies = [
  "password-hash",
  "sha2",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -4077,9 +4069,8 @@ checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+version = "0.22.0"
+source = "git+https://github.com/sujayakar/rust-rocksdb?rev=8651632f2d0b86a56cbad4fa4adaa4bf1ca96e2c#8651632f2d0b86a56cbad4fa4adaa4bf1ca96e2c"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -31,7 +31,10 @@ parking_lot = "0.12"
 rayon = "1.7.0"
 num_cpus = "1.16"
 itertools = "0.11"
-rocksdb = { version = "0.21.0", default-features = false, features = [ "snappy" ] }
+rocksdb = { git = "https://github.com/sujayakar/rust-rocksdb", rev = "8651632f2d0b86a56cbad4fa4adaa4bf1ca96e2c", default-features = false, features = [
+    "snappy",
+    "portable",
+] }
 uuid = { version = "1.4", features = ["v4", "serde"] }
 bincode = "1.3"
 serde = { version = "~1.0", features = ["derive", "rc"] }
@@ -43,7 +46,11 @@ thiserror = "1.0"
 atomic_refcell = "0.1.11"
 atomicwrites = "0.4.1"
 memmap2 = "0.7.1"
-schemars = { version = "0.8.13", features = ["uuid1", "preserve_order", "chrono"] }
+schemars = { version = "0.8.13", features = [
+    "uuid1",
+    "preserve_order",
+    "chrono",
+] }
 log = "0.4"
 geo = "0.26.0"
 geohash = "0.13.0"
@@ -63,9 +70,13 @@ smol_str = "0.2.0"
 
 sysinfo = "0.29"
 futures = "0.3.28"
-charabia = { version = "0.8.3", default-features = false, features = ["greek", "hebrew", "thai"] }
+charabia = { version = "0.8.3", default-features = false, features = [
+    "greek",
+    "hebrew",
+    "thai",
+] }
 
-common = {path = "../common"}
+common = { path = "../common" }
 
 tracing = { version = "0.1", features = ["async-await"], optional = true }
 
@@ -109,4 +120,3 @@ harness = false
 [[bench]]
 name = "boolean_filtering"
 harness = false
-


### PR DESCRIPTION
I'll update this PR if I can get the changes upstreamed to `rust-rocksdb` and released to crates.io.
